### PR TITLE
reconfigured to use IAM roles for s3 access

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,16 @@ Under "Source" select "My IP". If desired, you can also specify a range of IP
 addresses. Selecting "Anywhere" will allow traffic from all IP addresses (this
 is less secure).
 
-6. By default there are limits placed on the EC2 resources that a user has
+6. You will need to grant your EC2 instances access to your S3 bucket by 
+generating an new IAM role. To do this, naviate to the IAM Management
+Console. Select Roles, click create role, select AWS serice, select EC2,
+click Next: Permissions, then filter for ‘AmazonS3FullAccess’ then click checkbox 
+next to it, click Next: Tags (leave blank or add tag if desired), click Next: Review, 
+enter a Role name such as ‘S3FullAccessEC2’, then finally click Create role. 
+You will supply the Role name to the cellrangerAWS tool at the command
+line. 
+
+7. By default there are limits placed on the EC2 resources that a user has
 access to. EC2 limits are based on the total number of virtual CPUs that
 can be used. For example to launch an c5.24xlarge intance (96 CPUs) your EC2
 instance limit must be >96. A good starting point is to request a limit of 200.
@@ -142,6 +151,9 @@ requires the following arguments:
 	-t, the type of EC2 instance you want to use
 
 	-z, the availability zone (default is us-west-2a)
+    
+    -g, the name of the IAM role you generated to allow EC2 access to your 
+        S3 bucket (default is S3FullAccessEC2) 
 
 ### Running the test data
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ addresses. Selecting "Anywhere" will allow traffic from all IP addresses (this
 is less secure).
 
 6. You will need to grant your EC2 instances access to your S3 bucket by 
-generating an new IAM role. To do this, naviate to the IAM Management
-Console. Select Roles, click create role, select AWS serice, select EC2,
+generating a new IAM role. To do this, navigate to the IAM Management
+Console. Select Roles, click create role, select AWS service, select EC2,
 click Next: Permissions, then filter for ‘AmazonS3FullAccess’ then click checkbox 
 next to it, click Next: Tags (leave blank or add tag if desired), click Next: Review, 
 enter a Role name such as ‘S3FullAccessEC2’, then finally click Create role. 

--- a/cellrangerAWS
+++ b/cellrangerAWS
@@ -13,6 +13,7 @@ EC2_TYPE="none"
 MANUAL_MODE=false
 TRANSFER_DATA=true
 ZONE="us-west-2a"
+IAM="S3FullAccessEC2"
 
 # Usage message
 usage() {
@@ -27,6 +28,7 @@ OPTIONS
 -k, path to an ssh key linked to AWS account
 -t, EC2 instance type
 -z, EC2 availability zone (default is "$ZONE")
+-g, IAM instance profile name (default is "$IAM")
     """
 }
 
@@ -42,6 +44,7 @@ do
         k) KEY="$OPTARG" ;;
         t) EC2_TYPE="$OPTARG" ;;
 	z) ZONE="$OPTARG" ;;
+    g) IAM="$OPTARG" ;;
 	m) MANUAL_MODE=true ;;
         :)
             echo -e "\nERROR: -$OPTARG requires an argument"
@@ -207,6 +210,7 @@ launch_ec2() {
     local ec2_type="$3"
     local zone="$4"
     local key_name=$(basename -s .pem "$KEY")
+    local iam="$5"
 
     echo -e "\n$(get_time) Launching EC2 $ec2_type instance..."
 
@@ -246,6 +250,7 @@ launch_ec2() {
             --placement AvailabilityZone="$zone" \
             --block-device-mapping DeviceName="$root_dev",Ebs={VolumeSize="$vol_size"} \
             --key-name "$key_name" \
+            --iam-instance-profile Name="$iam" \
             | grep -E -o "InstanceId\": \"i\-[[:alnum:]]+" \
             | grep -E -o "i\-[[:alnum:]]+"
     )
@@ -321,30 +326,9 @@ run_cellranger() {
     local aws="/usr/local/bin/aws"
     local yaml=$(basename "$yaml")
 
-    # Configure AWS on EC2 instance
-    local iam_id=$(
-        cat "$HOME/.aws/credentials" \
-            | grep -E -A 2 "^\[default\]$" \
-            | grep "aws_access_key_id" \
-            | grep -E -o "[[:alnum:]]+$"
-    )
-
-    local iam_key=$(
-        cat "$HOME/.aws/credentials" \
-            | grep -E -A 2 "^\[default\]$" \
-            | grep "aws_secret_access_key" \
-            | grep -E -o "[[:alnum:]/\+]+$"
-    )
-
     local aws="/usr/local/bin/aws"
 
-    ssh -o "StrictHostKeyChecking no" -i "$KEY" "$ec2_ssh" \
-        "$aws configure set aws_access_key_id $iam_id"
-
-    ssh -i "$KEY" "$ec2_ssh" \
-        "$aws configure set aws_secret_access_key $iam_key"
-
-    scp -i "$KEY" "$CONFIG" "$ec2_ssh:~/PIPELINE" \
+    scp -q -o "StrictHostKeyChecking=no" -i "$KEY" "$CONFIG" "$ec2_ssh:~/PIPELINE" \
         > /dev/null
 
     # Add S3 bucket and EC2 instance ID to run.sh
@@ -382,7 +366,8 @@ main() {
         "$S3" \
         "$AMI" \
         "$EC2_TYPE" \
-        "$ZONE"
+        "$ZONE" \
+        "$IAM"
 
     # Check EC2 instance connectivity and retrieve EC2_SSH
     get_dns "$EC2"


### PR DESCRIPTION
Great tool, thanks for putting this together. I noticed that the EC2 configuration could be simplified by requiring the user to set up an IAM role, which is trivial to do in the console. This also makes the process more secure by not copying credentials to the instance.